### PR TITLE
Adds working filter with distinct for issue

### DIFF
--- a/app/resources/contact_resource.rb
+++ b/app/resources/contact_resource.rb
@@ -4,6 +4,13 @@ class ContactResource < JSONAPI::Resource
   attributes :first_name, :last_name, :email, :twitter
   has_many :phone_numbers
 
+  filter(
+    :last_name,
+    apply: ->(records, values, _options) {
+      records.where(last_name: values).distinct
+    }
+  )
+
   def self.creatable_fields(context)
     super + [:id]
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,9 +22,9 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
   # If using docker-compose to run the app, uncomment the next three lines:
-  host: <%= ENV['POSTGRES_PORT_5432_TCP_ADDR'] %>
-  port: <%= ENV['POSTGRES_PORT_5432_TCP_PORT'] %>
-  username: postgres
+  # host: <%= ENV['POSTGRES_PORT_5432_TCP_ADDR'] %>
+  # port: <%= ENV['POSTGRES_PORT_5432_TCP_PORT'] %>
+  # username: postgres
 
 development:
   <<: *default

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,8 @@ contacts = []
                              })
 end
 
+Contact.create(first_name: 'Bobby', last_name: 'Tables')
+
 contacts.each do |contact|
   contact.phone_numbers.create({
                                  name: 'cell',


### PR DESCRIPTION
> This is an example of something that's failing that I'm investigating, not something I'm merging in

Setup as normal & run:

```
curl -i -H "Accept: application/vnd.api+json" "http://localhost:3000/contacts?sort=last_name&filter%5Blast_name%5D=Tables"
```

This creates a postgres error because of the pluck_arel_attributes + the
sort

- Removing the sort works (but now everything is unsorted)
- Removing the distinct works (but for joins that need a distinct it
  doesn't)

I think I may need to put the distinct somewhere else, other than the
filter

This breaks right here: https://github.com/cerebris/jsonapi-resources/blob/v0.9.5/lib/jsonapi/resource.rb#L1282

because the sorted field isn't present in the query.

This breaks in 0.9.5 & 0.10.x latest beta 